### PR TITLE
pkp/pkp-lib#9021 handle objectsFileNamePart for XML export/deposit fi…

### DIFF
--- a/CrossrefExportPlugin.php
+++ b/CrossrefExportPlugin.php
@@ -190,7 +190,7 @@ class CrossrefExportPlugin extends DOIPubIdExportPlugin
         return (string) \APP\plugins\generic\crossref\CrossrefExportDeployment::class;
     }
 
-    public function exportAndDeposit($context, $objects, $filter, $objectsFileNamePart, string &$responseMessage, $noValidation = null): bool
+    public function exportAndDeposit($context, $objects, $filter, string &$responseMessage, $noValidation = null): bool
     {
         $fileManager = new FileManager();
         $resultErrors = [];
@@ -214,7 +214,7 @@ class CrossrefExportPlugin extends DOIPubIdExportPlugin
             $exportXml = $this->exportXML([$object], $filter, $context, $noValidation, $exportErrors);
             // Write the XML to a file.
             // export file name example: crossref-20160723-160036-articles-1-1.xml
-            $objectFileNamePart = $objectsFileNamePart . '-' . $object->getId();
+            $objectFileNamePart = $this->_getObjectFileNamePart($object);
             $exportFileName = $this->getExportFileName($this->getExportPath(), $objectFileNamePart, $context, '.xml');
             $fileManager->writeFile($exportFileName, $exportXml);
             // Deposit the XML file.
@@ -256,8 +256,7 @@ class CrossrefExportPlugin extends DOIPubIdExportPlugin
         $exportErrors = [];
         $exportXml = $this->exportXML($objects, $filter, $context, $noValidation, $exportErrors);
 
-        $objectFileNamePart = $objectsFileNamePart . '-' . $objects[0]->getId();
-        $exportFileName = $this->getExportFileName($this->getExportPath(), $objectFileNamePart, $context, '.xml');
+        $exportFileName = $this->getExportFileName($this->getExportPath(), $objectsFileNamePart, $context, '.xml');
 
         $fileManager->writeFile($exportFileName, $exportXml);
 
@@ -459,5 +458,20 @@ class CrossrefExportPlugin extends DOIPubIdExportPlugin
     public function getDepositSuccessNotificationMessageKey()
     {
         return 'plugins.importexport.common.register.success';
+    }
+
+    /**
+     * @param Submission|Issue $object
+     *
+     */
+    private function _getObjectFileNamePart(DataObject $object): string
+    {
+        if ($object instanceof Submission) {
+            return 'articles-' . $object->getId();
+        } elseif ($object instanceof Issue) {
+            return 'issues-' . $object->getId();
+        } else {
+            return '';
+        }
     }
 }

--- a/CrossrefPlugin.php
+++ b/CrossrefPlugin.php
@@ -293,7 +293,7 @@ class CrossrefPlugin extends GenericPlugin implements IDoiRegistrationAgency
         $exportPlugin = $this->_getExportPlugin();
         $filterName = $exportPlugin->getSubmissionFilter();
         $responseMessage = '';
-        $status = $exportPlugin->exportAndDeposit($context, $submissions, $filterName, 'articles', $responseMessage);
+        $status = $exportPlugin->exportAndDeposit($context, $submissions, $filterName, $responseMessage);
 
         return [
             'hasErrors' => !$status,
@@ -312,7 +312,7 @@ class CrossrefPlugin extends GenericPlugin implements IDoiRegistrationAgency
         $filterName = $exportPlugin->getIssueFilter();
         $xmlErrors = [];
 
-        $temporaryFileId = $exportPlugin->exportAsDownload($context, $issues, $filterName, 'articles', null, $xmlErrors);
+        $temporaryFileId = $exportPlugin->exportAsDownload($context, $issues, $filterName, 'issues', null, $xmlErrors);
         return ['temporaryFileId' => $temporaryFileId, 'xmlErrors' => $xmlErrors];
     }
 
@@ -324,7 +324,7 @@ class CrossrefPlugin extends GenericPlugin implements IDoiRegistrationAgency
         $exportPlugin = $this->_getExportPlugin();
         $filterName = $exportPlugin->getIssueFilter();
         $responseMessage = '';
-        $status = $exportPlugin->exportAndDeposit($context, $issues, $filterName, 'issues', $responseMessage);
+        $status = $exportPlugin->exportAndDeposit($context, $issues, $filterName, $responseMessage);
 
         return [
             'hasErrors' => !$status,


### PR DESCRIPTION
…le differently

s. https://github.com/pkp/pkp-lib/issues/9021

If several objects DOIs are being exported, there will be only one file, thus do not consider object ID in the objectsFileNamePart of the XML file name, use only 'articles' i.e. 'issues'.
However, several objects DOIs are deposited separately, one by one, thus the objectsFileNamePart will be hadnled here in the same way as in DataCite plugin.
