### PR TITLE
pkp/pkp-lib#9959 use createTextNode for article title and subtitle in…

### DIFF
--- a/filter/ArticleCrossrefXmlFilter.php
+++ b/filter/ArticleCrossrefXmlFilter.php
@@ -121,10 +121,12 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter
         $languageCounter = 1;
         foreach ($titleLanguages as $lang) {
             $titlesNode = $doc->createElementNS($deployment->getNamespace(), 'titles');
-            $titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title', $publication->getLocalizedTitle($lang, 'html')));
+            $titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title'));
+            $node->appendChild($doc->createTextNode($publication->getLocalizedTitle($lang, 'html')));
             if ($subtitle = $publication->getLocalizedSubTitle($lang, 'html')) {
-                $titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'subtitle', $subtitle));
-            }
+                $titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'subtitle'));
+                $node->appendChild($doc->createTextNode($subtitle));
+                }
             $journalArticleNode->appendChild($titlesNode);
             $languageCounter++;
             if ($languageCounter > 20) {
@@ -135,7 +137,7 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter
         // contributors
         $authors = $publication->getData('authors');
 
-        if (!empty($authors)) {
+        if ($authors->count() != 0) {
             $contributorsNode = $doc->createElementNS($deployment->getNamespace(), 'contributors');
 
             $isFirst = true;


### PR DESCRIPTION
… order to escapt it (e.g. &) properly

s. https://github.com/pkp/pkp-lib/issues/9959