### PR TITLE
pkp/pkp-lib#10796 indicate if orcid is authenticated

### DIFF
--- a/filter/ArticleCrossrefXmlFilter.php
+++ b/filter/ArticleCrossrefXmlFilter.php
@@ -160,7 +160,10 @@ class ArticleCrossrefXmlFilter extends IssueCrossrefXmlFilter
                     $personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'surname', htmlspecialchars(ucfirst($familyNames[$locale]), ENT_COMPAT, 'UTF-8')));
 
                     if ($author->getData('orcid')) {
-                        $personNameNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'ORCID', $author->getData('orcid')));
+                        $orcidNode = $doc->createElementNS($deployment->getNamespace(), 'ORCID', $author->getData('orcid'));
+                        $orcidAuthenticated = $author->getData('orcidAccessToken') ? 'true' : 'false';
+                        $orcidNode->setAttribute('authenticated', $orcidAuthenticated);
+                        $personNameNode->appendChild($orcidNode);
                     }
 
                     $hasAltName = false;


### PR DESCRIPTION
Adds `authenticated` attribute for ORCID - see: https://data.crossref.org/reports/help/schema_doc/5.3.1/index.html#ORCID

Once approved, I can also port to OPS & the 3.4 branches.